### PR TITLE
Update hook to use tk-3dsmaxplus engine.

### DIFF
--- a/hooks/shotgun_launch_publish.py
+++ b/hooks/shotgun_launch_publish.py
@@ -66,7 +66,7 @@ class LaunchAssociatedApp(HookBaseClass):
         elif path.endswith(".max"):
             # 3ds Max
             status = True
-            self._do_launch("launch3dsmax", "tk-3dsmax", path, context)            
+            self._do_launch("launch3dsmax", "tk-3dsmaxplus", path, context)
             
         elif path.endswith(".psd"):
             # Photoshop


### PR DESCRIPTION
Update the hook so that it uses the `tk-3dsmaxplus` engine instead of using the old `tk-3dsmax`.