### PR TITLE
Hook to pick a published file

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,7 +178,7 @@ class LaunchPublish(Application):
             return path_on_disk
         # If this PublishedFile came from a zero config publish, it will
         # have a file URL rather than a local path.
-        url = published_file.get("path").get("url")
+        url = published_file.get("path", {}).get("url")
         if url is not None:
             # We might have something like a %20, which needs to be
             # unquoted into a space, as an example.

--- a/app.py
+++ b/app.py
@@ -35,9 +35,10 @@ class LaunchPublish(Application):
     def init_app(self):
         deny_permissions = self.get_setting("deny_permissions")
         deny_platforms = self.get_setting("deny_platforms")
+        title = self.get_setting("display_name", "Open in Associated Application")
         
         p = {
-            "title": "Open in Associated Application",
+            "title": title,
             "deny_permissions": deny_permissions,
             "deny_platforms": deny_platforms,
             "supports_multiple_selection": False
@@ -66,7 +67,6 @@ class LaunchPublish(Application):
         if exit_code != 0:
             self.log_error("Failed to launch '%s'!" % cmd)
 
-
     def _launch_viewer(self, path):
         """
         Launches an image viewer based on config settings.
@@ -90,7 +90,7 @@ class LaunchPublish(Application):
         if system.startswith("linux"):
             cmd = '%s "%s" &' % (app_path, path)
         elif system == "darwin":
-            cmd = 'open -n "%s" --args "%s"' % (app_path, path)
+            cmd = 'open -n -a "%s" "%s"' % (app_path, path)
         elif system == "win32":
             cmd = 'start /B "Maya" "%s" "%s"' % (app_path, path)
         else:
@@ -107,7 +107,6 @@ class LaunchPublish(Application):
                           "on support@shotgunsoftware.com." % app_path )
 
     def launch_publish(self, entity_type, entity_ids):
-        
         published_file_entity_type = tank.util.get_published_file_entity_type(self.tank)
         
         if entity_type not in [published_file_entity_type, "Version"]:

--- a/app.py
+++ b/app.py
@@ -115,56 +115,18 @@ class LaunchPublish(Application):
 
         if len(entity_ids) != 1:
             raise Exception("Action only accepts a single item.")
+        try:
+            d = self.execute_hook(
+                "hook_get_published_file",
+                entity_type=entity_type,
+                entity_id=entity_ids[0],
+                published_file_entity_type=published_file_entity_type
+            )
+        except TankError as e:
+            self.log_error("Failed to get a published file for %s %s: %s" % (entity_type, entity_ids[0], e))
+            return
 
-        if entity_type == "Version":
-            # entity is a version so try to get the id 
-            # of the published file it is linked to:
-            if published_file_entity_type == "PublishedFile":
-                v = self.shotgun.find_one("Version", [["id", "is", entity_ids[0]]], ["published_files"])
-                if not v.get("published_files"):
-                    self.log_error("Sorry, this can only be used on Versions with an associated Published File.")
-                    return
-                publish_id = v["published_files"][0]["id"]
-            else:# == "TankPublishedFile":
-                v = self.shotgun.find_one("Version", [["id", "is", entity_ids[0]]], ["tank_published_file"])
-                if not v.get("tank_published_file"):
-                    self.log_error("Sorry, this can only be used on Versions with an associated Published File.")
-                    return
-                publish_id = v["tank_published_file"]["id"]
-            
-        else:
-            publish_id = entity_ids[0]
-
-        # first get the path to the file on the local platform
-        d = self.shotgun.find_one(published_file_entity_type, [["id", "is", publish_id]], ["path", "task", "entity"])
-        path_on_disk = d.get("path").get("local_path")
-
-        # If this PublishedFile came from a zero config publish, it will
-        # have a file URL rather than a local path.
-        if path_on_disk is None:
-            path_on_disk = d.get("path").get("url")
-            if path_on_disk is not None:
-                # We might have something like a %20, which needs to be
-                # unquoted into a space, as an example.
-                if "%" in path_on_disk:
-                    path_on_disk = urllib2.unquote(path_on_disk)
-
-                # If this came from a file url via a zero-config style publish
-                # then we'll need to remove that from the head in order to end
-                # up with the local disk path to the file.
-                #
-                # On Windows, we will have a path like file:///E:/path/to/file.jpg
-                # and we need to ditch all three of the slashes at the head. On
-                # other operating systems it will just be file:///path/to/file.jpg
-                # and we will want to keep the leading slash.
-                if sys.platform.startswith("win"):
-                    pattern = r"^file:///"
-                else:
-                    pattern = r"^file://"
-
-                path_on_disk = re.sub(pattern, "", path_on_disk)
-            else:
-                self.log_error("Unable to determine the path on disk for entity id=%s." % publish_id)
+        path_on_disk = self.get_path_on_disk(d)
 
         # first check if we should pass this to the viewer
         # hopefully this will cover most image sequence types
@@ -204,4 +166,39 @@ class LaunchPublish(Application):
             # hook didn't know how to launch this
             # just use std associated file launch
             self.launch(path_on_disk)
-        
+
+    def get_path_on_disk(self, published_file):
+        """
+        Retrieve, if possible, the path on disk of a PublishedFile.
+
+        :param published_file: A PublishedFile dictionary.
+        :returns: The path on disk if found, otherwise ``None``.
+        """
+        path_on_disk = published_file.get("path", {}).get("local_path")
+        if path_on_disk:
+            return path_on_disk
+        # If this PublishedFile came from a zero config publish, it will
+        # have a file URL rather than a local path.
+        url = published_file.get("path").get("url")
+        if url is not None:
+            # We might have something like a %20, which needs to be
+            # unquoted into a space, as an example.
+            if "%" in url:
+                url = urllib2.unquote(url)
+
+            # If this came from a file url via a zero-config style publish
+            # then we'll need to remove that from the head in order to end
+            # up with the local disk path to the file.
+            #
+            # On Windows, we will have a path like file:///E:/path/to/file.jpg
+            # and we need to ditch all three of the slashes at the head. On
+            # other operating systems it will just be file:///path/to/file.jpg
+            # and we will want to keep the leading slash.
+            if sys.platform.startswith("win"):
+                pattern = r"^file:///"
+            else:
+                pattern = r"^file://"
+            return re.sub(pattern, "", url)
+        else:
+            self.log_error("Unable to determine the path on disk for entity id=%s." % published_file["id"])
+            return None

--- a/hooks/shotgun_get_published_file.py
+++ b/hooks/shotgun_get_published_file.py
@@ -57,7 +57,7 @@ class GetPublishedFile(HookBaseClass):
             else:
                 published_files_field = "tank_published_file"
 
-            v = self.shotgun.find_one("Version", [["id", "is", entity_id]], [published_files_field])
+            v = self.parent.shotgun.find_one("Version", [["id", "is", entity_id]], [published_files_field])
             if not v.get(published_files_field):
                 raise TankError("Sorry, this can only be used on Versions with an associated published file.")
             if len(v[published_files_field]) == 1:
@@ -95,6 +95,6 @@ class GetPublishedFile(HookBaseClass):
         :param entity_id: a Shotgun ID.
         :returns: the published file with the right fields.
         """
-        return self.shotgun.find_one(
+        return self.parent.shotgun.find_one(
             entity_type,
             [["id", "is", entity_id]], ["path", "task", "entity"])

--- a/hooks/shotgun_get_published_file.py
+++ b/hooks/shotgun_get_published_file.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook executed to get a PublishedFile from a Version
+or a PublishedFile (legacy TankPublishedFile supported).
+
+If it is a Version and there's more than one PublishedFile linked
+to it, this hook allows to determine which PublishedFile to pick.
+
+The default implementation cycles through the `viewer_extensions`
+config parameter, and returns the first published file matching
+one of the extensions.
+
+This allows to select PublishedFiles based on the order of
+`viewer_extensions`.
+
+If none of the PublishedFiles match any of the extensions,
+return the first one in the list.
+"""
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class GetPublishedFile(HookBaseClass):
+    def execute(self, entity_type, entity_id, published_file_entity_type, **kwargs):
+        """
+        Given a Version, PublishedFile or TankPublishedFile,
+        return the PublishedFile or TankPublishedFile linked to it.
+
+        For a Version with multiple PublishedFiles,
+        return the first PublishedFile matching
+        `viewer_extensions` configuration parameter.
+        If no PublishedFile matches the extensions,
+        return the first one in the list.
+
+        :param str entity_type: Version, PublishedFile or TankPublishedFile.
+        :param int entity_id: The id of the entity.
+        :param str published_file_entity_type: PublishedFile or TankPublishedFile.
+        :returns: The selected PublishedFile
+        :raises: TankError if a PublishedFile cannot be found.
+        """
+        if entity_type == "Version":
+            # entity is a Version so try to get the id
+            # of the published file it is linked to
+            if published_file_entity_type == "PublishedFile":
+                published_files_field = "published_files"
+            else:
+                published_files_field = "tank_published_file"
+
+            v = self.shotgun.find_one("Version", [["id", "is", entity_id]], [published_files_field])
+            if not v.get(published_files_field):
+                raise TankError("Sorry, this can only be used on Versions with an associated published file.")
+            if len(v[published_files_field]) == 1:
+                publish_id = v[published_files_field][0]["id"]
+                return self.published_file(published_file_entity_type, publish_id)
+            else:
+                # if there are multiple published files, pick one.
+                viewer_extensions = self.parent.get_setting("viewer_extensions")
+                if not viewer_extensions:
+                    raise TankError(
+                        "Sorry, viewer extensions must be provided when a Version has multiple PublishedFiles"
+                    )
+                published_file_ids = [pf["id"] for pf in v[published_files_field]]
+                published_files = self.sgtk.shotgun.find(
+                    published_file_entity_type,
+                    [["id", "in", published_file_ids]],
+                    ["path", "task", "entity"]
+                )
+                for viewer_extension in viewer_extensions:
+                    for published_file in published_files:
+                        path_on_disk = self.parent.get_path_on_disk(published_file)
+                        if path_on_disk and path_on_disk.endswith(".%s" % viewer_extension):
+                            return published_file
+                return published_files[0]
+        else:
+            # entity is PublishedFile or TankPublishedFile. Return it
+            return self.published_file(entity_type, entity_id)
+
+    def published_file(self, entity_type, entity_id):
+        """
+        Return the PublishedFile or TankPublishedFile with path, task and entity
+        fields
+
+        :param entity_type: PublishedFile or TankPublishedFile
+        :param entity_id: a Shotgun ID.
+        :returns: the published file with the right fields.
+        """
+        return self.shotgun.find_one(
+            entity_type,
+            [["id", "is", entity_id]], ["path", "task", "entity"])

--- a/hooks/shotgun_get_published_file_for_viewer.py
+++ b/hooks/shotgun_get_published_file_for_viewer.py
@@ -44,13 +44,14 @@ class GetPublishedFileForViewer(HookBaseClass):
             raise TankError(
                 "Sorry, viewer extensions must be provided."
             )
-        path_on_disk = self.parent.get_path_on_disk(published_file)
+        sg_published_file = self.published_file(entity_type, published_file["id"])
+        path_on_disk = self.parent.get_path_on_disk(sg_published_file)
         if path_on_disk:
             for viewer_extension in viewer_extensions:
                 if path_on_disk.endswith(".%s" % viewer_extension):
-                    return self.published_file(entity_type, published_file["id"])
-        raise TankError("Published File %s does not match viewer extensions %s" % (
-            published_file,
+                    return sg_published_file
+        raise TankError("PublishedFile path %s does not match viewer extensions %s" % (
+            path_on_disk,
             viewer_extensions
         ))
 

--- a/hooks/shotgun_get_published_file_for_viewer.py
+++ b/hooks/shotgun_get_published_file_for_viewer.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Hook executed to get a PublishedFile from a Version
+or a PublishedFile (legacy TankPublishedFile supported).
+
+This implementation returns the first published file it finds
+matching extensions in the order of viewer extensions.
+If none are found, raise a TankError.
+"""
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class GetPublishedFileForViewer(HookBaseClass):
+    """
+    In order to work, this hook needs to inherit from shotgun_get_published_file.GetPublishedFile
+    """
+
+    def resolve_single_file(self, entity_type, published_file):
+        """
+        Decide wether or not to return the published file, or raise a TankError.
+        This default implementation returns the published file only if it matches
+        one of the viewer_extensions.
+
+        :param str entity_type: PublishedFile or TankPublishedFile.
+        :param dict published_file: The published file.
+        :returns: The published file with the right fields.
+        :raises: TankError
+        """
+        viewer_extensions = self.parent.get_setting("viewer_extensions")
+        if not viewer_extensions:
+            raise TankError(
+                "Sorry, viewer extensions must be provided."
+            )
+        path_on_disk = self.parent.get_path_on_disk(published_file)
+        if path_on_disk:
+            for viewer_extension in viewer_extensions:
+                if path_on_disk.endswith(".%s" % viewer_extension):
+                    return self.published_file(entity_type, published_file["id"])
+        raise TankError("Published File %s does not match viewer extensions %s" % (
+            published_file,
+            viewer_extensions
+        ))
+
+    def resolve_multiple_files(self, published_file_type, published_files):
+        """
+        Decide which published file to return, or raise a TankError.
+        Return the first published file matching a viewer extension,
+        otherwise raise a TankError.
+
+        :param str published_file_type: PublishedFile or TankPublishedFile.
+        :param list published_files: The published files.
+        :returns: The first published file with the right fields.
+        :raises: TankError
+        """
+        viewer_extensions = self.parent.get_setting("viewer_extensions")
+        if not viewer_extensions:
+            raise TankError(
+                "Sorry, viewer extensions must be provided."
+            )
+        published_file_ids = [pf["id"] for pf in published_files]
+        published_files = self.sgtk.shotgun.find(
+            published_file_type,
+            [["id", "in", published_file_ids]],
+            self._PUBLISHED_FILE_FIELDS
+        )
+        for viewer_extension in viewer_extensions:
+            for published_file in published_files:
+                path_on_disk = self.parent.get_path_on_disk(published_file)
+                if path_on_disk and path_on_disk.endswith(".%s" % viewer_extension):
+                    return published_file
+        raise TankError(
+            "Could not find a published file matching viewer extensions %s. Published files: %s" % (
+                viewer_extensions,
+                published_files
+            )
+        )
+

--- a/info.yml
+++ b/info.yml
@@ -68,6 +68,16 @@ configuration:
         default_value: shotgun_launch_publish
         parameters: [path, context, associated_entity]
 
+    hook_get_published_file:
+        type: hook
+        description: Given a Version or a PublishedFile (legacy TankPublishedFile
+                      supported), return its linked PublishedFile. Path, task and
+                      entity fields must be returned.
+                     This hook allows to deal with the case of a Version with
+                     multiple PublishedFiles linked to it. The default implementation
+                     will select a PublishedFile based on the viewer_extensions order.
+        default_value: shotgun_get_published_file
+
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
Added a hook to get a PublishedFile or a TankPublishedFile given an entity_type and and entity_id.
This moves the logic of picking a published file for an entity into the hook.

The default implementation of the hook picks:
* if entity_type is PublishedFile or TankPublishedFile, the logic remains the same
* if it is a Version, but it has a single published file attached, the logic remains the same
* if it is a Version with multiple PublishedFiles, select one respecting the order of the config parameter `viewer_extensions`. If none is found, pick the first published file.