### PR TITLE
Sg-8610 Adds support for Photoshopcc and After Effects

### DIFF
--- a/hooks/shotgun_launch_publish.py
+++ b/hooks/shotgun_launch_publish.py
@@ -71,7 +71,12 @@ class LaunchAssociatedApp(HookBaseClass):
         elif path.endswith(".psd"):
             # Photoshop
             status = True
-            self._do_launch("launchphotoshop", "tk-photoshop", path, context)
+            self._do_launch("launchphotoshop", "tk-photoshopcc", path, context)
+
+        elif path.endswith(".aep"):
+            # Photoshop
+            status = True
+            self._do_launch("launchaftereffects", "tk-aftereffects", path, context)
             
         # return an indication to the app whether we launched or not
         # if we return True here, the app will just exit

--- a/hooks/shotgun_launch_publish.py
+++ b/hooks/shotgun_launch_publish.py
@@ -77,6 +77,11 @@ class LaunchAssociatedApp(HookBaseClass):
             # Photoshop
             status = True
             self._do_launch("launchaftereffects", "tk-aftereffects", path, context)
+
+        elif path.endswith(".hip"):
+            # Photoshop
+            status = True
+            self._do_launch("launchhoudini", "tk-houdini", path, context)
             
         # return an indication to the app whether we launched or not
         # if we return True here, the app will just exit


### PR DESCRIPTION
This allows launch publish to work with the newer Photoshop engine and the aftereffects engine.

Requires:
https://github.com/shotgunsoftware/tk-photoshopcc/pull/68
https://github.com/shotgunsoftware/tk-aftereffects/pull/29

For Photoshop and After Effects to actually open the file. If running against an earlier version of the engine it will just open Photoshop in the correct context, but without the file being opened.

Also requires:
https://github.com/shotgunsoftware/tk-houdini/pull/43
Otherwise Houdini will crash on startup.